### PR TITLE
Improve multitouch support and add create/link-mode buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,5 +17,10 @@
     <input id="newTask" type="text"></input>
     <div id="nodeA"  class="task">Water the plants</div>
     <div id="nodeB"  class="task">Say hi to grandma</div>
+    <button id="create-task-button">Create task</button>
+    <label id="link-mode-checkbox">
+      Link mode
+      <input type="checkbox">
+    </label>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -17,6 +17,7 @@ body {
   font-family: "PermanentMarker";
   font-size: 2em;
   line-height: 1em; /* ensure that the bounding box is not too high */
+  cursor: pointer;
 }
 
 #arrows {
@@ -50,4 +51,16 @@ body {
 
   font-family: "PermanentMarker";
   font-size: 1.5em;
+}
+
+#create-task-button {
+  position: absolute;
+  left: 5px;
+  top: 50px;
+}
+
+#link-mode-checkbox {
+  position: absolute;
+  left: 5px;
+  top: 85px;
 }


### PR DESCRIPTION
- The previous task dragging implementation did not allow for multiple tasks to be dragged at once because it set the single container.onpointermove handler rather using addEventListener()
- An isDragging flag is set on tasks to prevent multiple pointer events from attempting to drag the same task at once.
- document.elementFromPoint() is used to perform hit-testing even when the pointer has been captured.
- The create task button and link mode checkbox allow editing the graph on a touch-only device.