### PR TITLE
Migrate the Toolbar to React

### DIFF
--- a/src/scripts/App.tsx
+++ b/src/scripts/App.tsx
@@ -1,10 +1,18 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { closeMenubar } from ".";
 import GraphInput from "./GraphInput";
-import { clearGraph, Graph, loadGraph } from "./graph";
+import {
+  clearGraph,
+  completeSelected,
+  deleteSelected,
+  Graph,
+  loadGraph,
+} from "./graph";
 import MenuBar from "./MenuBar";
 import { saveToFile, saveToLocalStorage } from "./storage";
 import useAppShortcuts from "./useAppShortcuts";
+import Toolbar from "./Toolbar";
+import { getElementById } from "./misc";
 
 const App = (): JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -42,12 +50,64 @@ const App = (): JSX.Element => {
     );
   };
 
+  const [tasksSelected, setTasksSelected] = useState(false);
+
+  // Update tasksSelected when the graph sends a selectionchanged event
+  useEffect(() => {
+    const onSelectionChanged = (event: Event) => {
+      const customEvent = event as CustomEvent<HTMLElement[]>;
+      setTasksSelected(customEvent.detail.length > 0);
+    };
+    const graph = getElementById("graph");
+    graph.addEventListener("selectionchanged", onSelectionChanged);
+    return () =>
+      graph.removeEventListener("selectionchanged", onSelectionChanged);
+  });
+
+  const [linkMode, setLinkMode] = useState(false);
+
+  const renderToolbar = () => {
+    const onCreateTask = () => {
+      const newTask = getElementById("newTask");
+      newTask.style.display = "block";
+      newTask.focus();
+    };
+
+    const onChangeLinkMode = () => setLinkMode((linkMode) => !linkMode);
+
+    const onComplete = () => {
+      completeSelected();
+      saveToLocalStorage();
+    };
+
+    const onDelete = () => {
+      deleteSelected();
+      saveToLocalStorage();
+    };
+
+    return tasksSelected ? (
+      <Toolbar
+        tasksSelected={true}
+        onComplete={onComplete}
+        onDelete={onDelete}
+      />
+    ) : (
+      <Toolbar
+        tasksSelected={false}
+        linkMode={linkMode}
+        onCreateTask={onCreateTask}
+        onChangeLinkMode={onChangeLinkMode}
+      />
+    );
+  };
+
   useAppShortcuts(loadFromFile);
 
   return (
     <>
       {renderGraphInput()}
       {renderMenuBar()}
+      {renderToolbar()}
     </>
   );
 };

--- a/src/scripts/App.tsx
+++ b/src/scripts/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { closeMenubar } from ".";
 import GraphInput from "./GraphInput";
 import {
@@ -13,6 +13,7 @@ import { saveToFile, saveToLocalStorage } from "./storage";
 import useAppShortcuts from "./useAppShortcuts";
 import Toolbar from "./Toolbar";
 import { getElementById } from "./misc";
+import useTasksSelected from "./useTasksSelected";
 
 const App = (): JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -50,21 +51,9 @@ const App = (): JSX.Element => {
     );
   };
 
-  const [tasksSelected, setTasksSelected] = useState(false);
-
-  // Update tasksSelected when the graph sends a selectionchanged event
-  useEffect(() => {
-    const onSelectionChanged = (event: Event) => {
-      const customEvent = event as CustomEvent<HTMLElement[]>;
-      setTasksSelected(customEvent.detail.length > 0);
-    };
-    const graph = getElementById("graph");
-    graph.addEventListener("selectionchanged", onSelectionChanged);
-    return () =>
-      graph.removeEventListener("selectionchanged", onSelectionChanged);
-  });
-
   const [linkMode, setLinkMode] = useState(false);
+
+  const tasksSelected = useTasksSelected();
 
   const renderToolbar = () => {
     const onCreateTask = () => {

--- a/src/scripts/App.tsx
+++ b/src/scripts/App.tsx
@@ -62,7 +62,7 @@ const App = (): JSX.Element => {
       newTask.focus();
     };
 
-    const onChangeLinkMode = () => setLinkMode((linkMode) => !linkMode);
+    const onChangeLinkMode = () => setLinkMode((state) => !state);
 
     const onComplete = () => {
       completeSelected();

--- a/src/scripts/Toolbar.css
+++ b/src/scripts/Toolbar.css
@@ -1,0 +1,37 @@
+.Toolbar {
+  position: fixed;
+  right: 2em;
+  bottom: 2em;
+  z-index: 1;
+}
+
+.Toolbar__button {
+  width: 5em;
+  height: 5em;
+}
+
+.Toolbar__delete-selected-button {
+  background-image: url("resources/feather/trash-2.svg");
+}
+
+.Toolbar__complete-selected-button {
+  background-image: url("resources/feather/check-circle.svg");
+}
+
+.Toolbar__create-task-button {
+  background-image: url("resources/feather/plus-circle.svg");
+}
+
+.Toolbar__change-link-mode-button {
+  background-image: url("resources/feather/link.svg");
+
+  border-bottom: 0.2rem solid transparent;
+
+  /* Display the button correctly even with the border */
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.Toolbar__change-link-mode-button--active {
+  border-bottom: 0.2rem solid;
+}

--- a/src/scripts/Toolbar.css
+++ b/src/scripts/Toolbar.css
@@ -10,19 +10,19 @@
   height: 5em;
 }
 
-.Toolbar__delete-selected-button {
+.Toolbar__button-delete-selected {
   background-image: url("resources/feather/trash-2.svg");
 }
 
-.Toolbar__complete-selected-button {
+.Toolbar__button-complete-selected {
   background-image: url("resources/feather/check-circle.svg");
 }
 
-.Toolbar__create-task-button {
+.Toolbar__button-create-task {
   background-image: url("resources/feather/plus-circle.svg");
 }
 
-.Toolbar__change-link-mode-button {
+.Toolbar__button-change-link-mode {
   background-image: url("resources/feather/link.svg");
 
   border-bottom: 0.2rem solid transparent;
@@ -32,6 +32,6 @@
   background-position: center;
 }
 
-.Toolbar__change-link-mode-button--active {
+.Toolbar__button-change-link-mode--active {
   border-bottom: 0.2rem solid;
 }

--- a/src/scripts/Toolbar.tsx
+++ b/src/scripts/Toolbar.tsx
@@ -24,9 +24,12 @@ const Toolbar = (props: Props): JSX.Element => {
           <button
             aria-label="Change Link Mode"
             onClick={onChangeLinkMode}
-            className={`Toolbar__button Toolbar__change-link-mode-button ${
-              linkMode ? "Toolbar__change-link-mode-button--active" : ""
-            } iconButton`}
+            className={`
+              Toolbar__button
+              Toolbar__change-link-mode-button
+              ${linkMode ? "Toolbar__change-link-mode-button--active" : ""}
+              iconButton
+            `}
           />
           <button
             aria-label="Create Task"

--- a/src/scripts/Toolbar.tsx
+++ b/src/scripts/Toolbar.tsx
@@ -26,15 +26,15 @@ const Toolbar = (props: Props): JSX.Element => {
             onClick={onChangeLinkMode}
             className={`
               Toolbar__button
-              Toolbar__change-link-mode-button
-              ${linkMode ? "Toolbar__change-link-mode-button--active" : ""}
+              Toolbar__button-change-link-mode
+              ${linkMode ? "Toolbar__button-change-link-mode--active" : ""}
               iconButton
             `}
           />
           <button
             aria-label="Create Task"
             onClick={onCreateTask}
-            className="Toolbar__button Toolbar__create-task-button iconButton"
+            className="Toolbar__button Toolbar__button-create-task iconButton"
           />
         </>
       );
@@ -46,12 +46,12 @@ const Toolbar = (props: Props): JSX.Element => {
         <button
           aria-label="Delete Selected"
           onClick={onDelete}
-          className="Toolbar__button Toolbar__delete-selected-button iconButton"
+          className="Toolbar__button Toolbar__button-delete-selected iconButton"
         />
         <button
           aria-label="Complete Selected"
           onClick={onComplete}
-          className="Toolbar__button Toolbar__complete-selected-button iconButton"
+          className="Toolbar__button Toolbar__button-complete-selected iconButton"
         />
       </>
     );

--- a/src/scripts/Toolbar.tsx
+++ b/src/scripts/Toolbar.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+import "./Toolbar.css";
+
+type Props =
+  | {
+      tasksSelected: false;
+      linkMode: boolean;
+      onChangeLinkMode: () => void;
+      onCreateTask: () => void;
+    }
+  | {
+      tasksSelected: true;
+      onComplete: () => void;
+      onDelete: () => void;
+    };
+
+const Toolbar = (props: Props): JSX.Element => {
+  const renderButtons = () => {
+    if (!props.tasksSelected) {
+      const { linkMode, onChangeLinkMode, onCreateTask } = props;
+      return (
+        <>
+          <button
+            onClick={onChangeLinkMode}
+            className={`Toolbar__button Toolbar__change-link-mode-button ${
+              linkMode ? "Toolbar__change-link-mode-button--active" : ""
+            } iconButton`}
+          />
+          <button
+            onClick={onCreateTask}
+            className="Toolbar__button Toolbar__create-task-button iconButton"
+          />
+        </>
+      );
+    }
+    // props.tasksSelected === true
+    const { onComplete, onDelete } = props;
+    return (
+      <>
+        <button
+          onClick={onDelete}
+          // TODO Should it be delete-selected?
+          className="Toolbar__button Toolbar__delete-selected-button iconButton"
+        />
+        <button
+          onClick={onComplete}
+          className="Toolbar__button Toolbar__complete-selected-button iconButton"
+        />
+      </>
+    );
+  };
+
+  return (
+    <div className="Toolbar">
+      {renderButtons()}
+
+      {/* TODO Remove: Temporary element used to communicate with graph */}
+      <input
+        style={{ display: "none" }}
+        type="checkbox"
+        checked={!props.tasksSelected && props.linkMode}
+        id="linkModeCheckbox"
+      />
+    </div>
+  );
+};
+
+export default Toolbar;

--- a/src/scripts/Toolbar.tsx
+++ b/src/scripts/Toolbar.tsx
@@ -43,7 +43,6 @@ const Toolbar = (props: Props): JSX.Element => {
         <button
           aria-label="Delete Selected"
           onClick={onDelete}
-          // TODO Should it be delete-selected?
           className="Toolbar__button Toolbar__delete-selected-button iconButton"
         />
         <button

--- a/src/scripts/Toolbar.tsx
+++ b/src/scripts/Toolbar.tsx
@@ -22,12 +22,14 @@ const Toolbar = (props: Props): JSX.Element => {
       return (
         <>
           <button
+            aria-label="Change Link Mode"
             onClick={onChangeLinkMode}
             className={`Toolbar__button Toolbar__change-link-mode-button ${
               linkMode ? "Toolbar__change-link-mode-button--active" : ""
             } iconButton`}
           />
           <button
+            aria-label="Create Task"
             onClick={onCreateTask}
             className="Toolbar__button Toolbar__create-task-button iconButton"
           />
@@ -39,11 +41,13 @@ const Toolbar = (props: Props): JSX.Element => {
     return (
       <>
         <button
+          aria-label="Delete Selected"
           onClick={onDelete}
           // TODO Should it be delete-selected?
           className="Toolbar__button Toolbar__delete-selected-button iconButton"
         />
         <button
+          aria-label="Complete Selected"
           onClick={onComplete}
           className="Toolbar__button Toolbar__complete-selected-button iconButton"
         />

--- a/src/scripts/graph.ts
+++ b/src/scripts/graph.ts
@@ -334,8 +334,8 @@ export function initGraph(): void {
     const pointerId = event.pointerId;
     itemsContainer.setPointerCapture(pointerId);
     const initialPosition = { x: event.clientX, y: event.clientY };
-    const linkModeCheckbox = querySelector(
-      "#linkModeCheckbox input"
+    const linkModeCheckbox = getElementById(
+      "linkModeCheckbox"
     ) as HTMLInputElement;
     if (event.shiftKey || linkModeCheckbox.checked) {
       // Initiate link creation

--- a/src/scripts/index.tsx
+++ b/src/scripts/index.tsx
@@ -30,35 +30,6 @@ const setupApp = () => {
   });
 };
 
-function setupToolbar() {
-  const newTask = getElementById("newTask");
-  getElementById("createTaskButton").onclick = () => {
-    newTask.style.display = "block";
-    newTask.focus();
-  };
-
-  getElementById("deleteTaskButton").addEventListener("click", () => {
-    deleteSelected();
-    saveToLocalStorage();
-  });
-
-  getElementById("completeTaskButton").addEventListener("click", () => {
-    completeSelected();
-    saveToLocalStorage();
-  });
-}
-
-function updateToolbar(selection: boolean) {
-  const createTaskButton = getElementById("createTaskButton");
-  const deleteTaskButton = getElementById("deleteTaskButton");
-  const completeTaskButton = getElementById("completeTaskButton");
-  const linkModeCheckbox = getElementById("linkModeCheckbox");
-  createTaskButton.style.display = !selection ? "block" : "none";
-  deleteTaskButton.style.display = selection ? "block" : "none";
-  completeTaskButton.style.display = selection ? "block" : "none";
-  linkModeCheckbox.style.display = !selection ? "block" : "none";
-}
-
 function setupNewTask() {
   const newTask = getElementById("newTask") as HTMLInputElement;
   const stopNewTask = () => {
@@ -81,15 +52,11 @@ function setupNewTask() {
 
 document.addEventListener("DOMContentLoaded", () => {
   setupApp();
-  setupToolbar();
   setupNewTask();
 
   const graph = getElementById("graph");
   graph.addEventListener("taskmoved", saveToLocalStorage);
   graph.addEventListener("newdependency", saveToLocalStorage);
-  graph.addEventListener("selectionchanged", function (event) {
-    updateToolbar((event as CustomEvent<HTMLElement[]>).detail.length > 0);
-  });
 
   initGraph();
 

--- a/src/scripts/index.tsx
+++ b/src/scripts/index.tsx
@@ -3,12 +3,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App.js";
-import {
-  initGraph,
-  addTask,
-  deleteSelected,
-  completeSelected,
-} from "./graph.js";
+import { initGraph, addTask } from "./graph.js";
 
 import { getElementById } from "./misc.js";
 import { loadFromLocalStorage, saveToLocalStorage } from "./storage.js";

--- a/src/scripts/useTasksSelected.ts
+++ b/src/scripts/useTasksSelected.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+import { getElementById } from "./misc";
+
+/**
+ * Update tasksSelected when the graph sends a selectionchanged event
+ */
+const useTasksSelected = (): boolean => {
+  const [tasksSelected, setTasksSelected] = useState(false);
+
+  useEffect(() => {
+    const onSelectionChanged = (event: Event) => {
+      const customEvent = event as CustomEvent<HTMLElement[]>;
+      setTasksSelected(customEvent.detail.length > 0);
+    };
+    const graph = getElementById("graph");
+    graph.addEventListener("selectionchanged", onSelectionChanged);
+    return () =>
+      graph.removeEventListener("selectionchanged", onSelectionChanged);
+  });
+
+  return tasksSelected;
+};
+
+export default useTasksSelected;

--- a/src/scripts/useTasksSelected.ts
+++ b/src/scripts/useTasksSelected.ts
@@ -16,7 +16,7 @@ const useTasksSelected = (): boolean => {
     graph.addEventListener("selectionchanged", onSelectionChanged);
     return () =>
       graph.removeEventListener("selectionchanged", onSelectionChanged);
-  });
+  }, []);
 
   return tasksSelected;
 };

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,33 +10,6 @@
   <body>
     <div id="root"></div>
     <button id="menubarOpenButton" class="iconButton"></button>
-    <div id="toolbar">
-      <button id="deleteTaskButton" class="iconButton"></button>
-      <label id="linkModeCheckbox">
-        <input type="checkbox" />
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="feather feather-link"
-        >
-          <path
-            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-          ></path>
-          <path
-            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-          ></path>
-        </svg>
-      </label>
-      <button id="completeTaskButton" class="iconButton"></button>
-      <button id="createTaskButton" class="iconButton"></button>
-    </div>
     <div id="graph">
       <p id="zoomIndicator"></p>
       <div id="itemsContainer">

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -121,21 +121,6 @@ body {
   font-size: 1.5em;
 }
 
-#toolbar {
-  padding: 2em;
-  position: fixed;
-  bottom: 0;
-  right: 0;
-  z-index: 1;
-  display: flex;
-  align-items: center;
-}
-
-#toolbar button {
-  width: 4em;
-  height: 4em;
-}
-
 .iconButton {
   background-size: contain;
   background-color: transparent;
@@ -144,31 +129,6 @@ body {
 
 button {
   cursor: pointer;
-}
-
-#linkModeCheckbox svg {
-  width: 4em;
-  height: 4em;
-}
-
-#linkModeCheckbox input:checked + svg {
-  border-bottom: 0.2rem solid;
-}
-
-#linkModeCheckbox input {
-  display: none;
-}
-
-#deleteTaskButton {
-  background-image: url("resources/feather/trash-2.svg");
-}
-
-#completeTaskButton {
-  background-image: url("resources/feather/check-circle.svg");
-}
-
-#createTaskButton {
-  background-image: url("resources/feather/plus-circle.svg");
 }
 
 #menubarOpenButton {


### PR DESCRIPTION
The graph is currently still a big chunk of js

It used to get wether we're in link mode or not by looking at a global checkbox. Kept a similar one here to not break the graph

The graph sends `selectionchanged` events whenever the selected tasks in the graph changes (Ctrl-A, click on background, ...)

We update `tasksSelected` with the `useTasksSelected` hook accordingly

Note: The `App.tsx` is starting to get fat 🤔