### PR TITLE
React zoom

### DIFF
--- a/src/scripts/App/Graph/Graph.css
+++ b/src/scripts/App/Graph/Graph.css
@@ -4,7 +4,7 @@
   overflow: hidden;
 }
 
-#zoomIndicator {
+.Graph__zoom-indicator {
   position: absolute;
   top: 0;
   right: 0;

--- a/src/scripts/App/Graph/Graph.tsx
+++ b/src/scripts/App/Graph/Graph.tsx
@@ -45,8 +45,8 @@ const Graph = (): JSX.Element => {
       onWheel={onWheel}
       id="graph"
       ref={graphRef}
-      data-window-x={window.pan.x}
-      data-window-y={window.pan.y}
+      data-window-pan-x={window.pan.x}
+      data-window-pan-y={window.pan.y}
       data-window-zoom={window.zoom}
     >
       <p className="Graph__zoom-indicator">

--- a/src/scripts/App/Graph/Graph.tsx
+++ b/src/scripts/App/Graph/Graph.tsx
@@ -7,19 +7,19 @@ import { snap } from "@/misc";
 const Graph = (): JSX.Element => {
   useEffect(initGraph, []);
 
-  const [panzoom, setPanzoom] = useState({ pan: { x: 0, y: 0 }, zoom: 1 });
+  const [window, setWindow] = useState({ pan: { x: 0, y: 0 }, zoom: 1 });
 
   const onWheel: React.WheelEventHandler = (event) => {
     const factor = event.deltaY < 0 ? 1.1 : 0.9;
     const target = 1;
     const offset = 0.1;
-    const newZoom = snap(target)(offset)(panzoom.zoom * factor);
-    setPanzoom((state) => ({ ...state, zoom: newZoom }));
+    const newZoom = snap(target)(offset)(window.zoom * factor);
+    setWindow((state) => ({ ...state, zoom: newZoom }));
   };
 
   const graphRef = useRef<HTMLDivElement>(null);
 
-  // Update panzoom when the graph sends a graphmoved event
+  // Update window when the graph sends a graphmoved event
   useEffect(() => {
     if (!graphRef.current) return;
     const element = graphRef.current;
@@ -29,15 +29,15 @@ const Graph = (): JSX.Element => {
       } = event as CustomEvent<{
         pan: { x: number; y: number };
       }>;
-      setPanzoom((state) => ({ ...state, pan }));
+      setWindow((state) => ({ ...state, pan }));
     };
     element.addEventListener("graphmoved", handler);
     return () => element.removeEventListener("graphmoved", handler);
   });
 
   const itemsContainerTransform = `
-    translate(${panzoom.pan.x}px, ${panzoom.pan.y}px)
-    scale(${panzoom.zoom})
+    translate(${window.pan.x}px, ${window.pan.y}px)
+    scale(${window.zoom})
   `;
 
   return (
@@ -45,12 +45,12 @@ const Graph = (): JSX.Element => {
       onWheel={onWheel}
       id="graph"
       ref={graphRef}
-      data-panzoom-x={panzoom.pan.x}
-      data-panzoom-y={panzoom.pan.y}
-      data-panzoom-zoom={panzoom.zoom}
+      data-window-x={window.pan.x}
+      data-window-y={window.pan.y}
+      data-window-zoom={window.zoom}
     >
       <p className="Graph__zoom-indicator">
-        {panzoom.zoom !== 1 && Math.floor(panzoom.zoom * 100) + "% zoom"}
+        {window.zoom !== 1 && Math.floor(window.zoom * 100) + "% zoom"}
       </p>
       <div id="itemsContainer" style={{ transform: itemsContainerTransform }}>
         <svg id="arrows">

--- a/src/scripts/App/Graph/Graph.tsx
+++ b/src/scripts/App/Graph/Graph.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from "react";
-
+import React, { useEffect, useState } from "react";
 import { initGraph, updateZoom } from "@/graph";
 
 import "./Graph.css";
@@ -7,14 +6,19 @@ import "./Graph.css";
 const Graph = (): JSX.Element => {
   useEffect(initGraph, []);
 
+  const [zoom, setZoom] = useState(1);
+
   const onWheel: React.WheelEventHandler = (event) => {
     const factor = event.deltaY < 0 ? 1.1 : 0.9;
-    updateZoom(factor);
+    const newZoom = updateZoom(factor);
+    setZoom(newZoom);
   };
 
   return (
     <div onWheel={onWheel} id="graph">
-      <p id="zoomIndicator"></p>
+      <p className="Graph__zoom-indicator">
+        {zoom !== 1 && Math.floor(zoom * 100) + "% zoom"}
+      </p>
       <div id="itemsContainer">
         <svg id="arrows">
           <defs>

--- a/src/scripts/App/Graph/Graph.tsx
+++ b/src/scripts/App/Graph/Graph.tsx
@@ -1,14 +1,19 @@
 import React, { useEffect } from "react";
 
-import { initGraph } from "@/graph";
+import { initGraph, updateZoom } from "@/graph";
 
 import "./Graph.css";
 
 const Graph = (): JSX.Element => {
   useEffect(initGraph, []);
 
+  const onWheel: React.WheelEventHandler = (event) => {
+    const factor = event.deltaY < 0 ? 1.1 : 0.9;
+    updateZoom(factor);
+  };
+
   return (
-    <div id="graph">
+    <div onWheel={onWheel} id="graph">
       <p id="zoomIndicator"></p>
       <div id="itemsContainer">
         <svg id="arrows">

--- a/src/scripts/App/Graph/Graph.tsx
+++ b/src/scripts/App/Graph/Graph.tsx
@@ -11,7 +11,9 @@ const Graph = (): JSX.Element => {
 
   const onWheel: React.WheelEventHandler = (event) => {
     const factor = event.deltaY < 0 ? 1.1 : 0.9;
-    const newZoom = snap(1)(0.1)(panzoom.zoom * factor);
+    const target = 1;
+    const offset = 0.1;
+    const newZoom = snap(target)(offset)(panzoom.zoom * factor);
     setPanzoom((state) => ({ ...state, zoom: newZoom }));
   };
 

--- a/src/scripts/App/Graph/Graph.tsx
+++ b/src/scripts/App/Graph/Graph.tsx
@@ -1,23 +1,52 @@
-import React, { useEffect, useState } from "react";
-import { initGraph, updateZoom } from "@/graph";
+import React, { useEffect, useRef, useState } from "react";
+import { initGraph, updatePanzoom } from "@/graph";
 
 import "./Graph.css";
+import { snap } from "@/misc";
 
 const Graph = (): JSX.Element => {
   useEffect(initGraph, []);
 
-  const [zoom, setZoom] = useState(1);
+  const [panzoom, setPanzoom] = useState({ pan: { x: 0, y: 0 }, zoom: 1 });
 
   const onWheel: React.WheelEventHandler = (event) => {
     const factor = event.deltaY < 0 ? 1.1 : 0.9;
-    const newZoom = updateZoom(factor);
-    setZoom(newZoom);
+    const newZoom = snap(1)(0.1)(panzoom.zoom * factor);
+    setPanzoom((state) => ({ ...state, zoom: newZoom }));
   };
 
+  useEffect(updatePanzoom, [panzoom]);
+
+  const graphRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!graphRef.current) return;
+    const element = graphRef.current;
+    const handler = (event: Event) => {
+      const {
+        detail: { pan },
+      } = event as CustomEvent<{
+        pan: { x: number; y: number };
+      }>;
+      setPanzoom((state) => ({ ...state, pan }));
+
+      updatePanzoom();
+    };
+    element.addEventListener("graphmoved", handler);
+    return () => element.removeEventListener("graphmoved", handler);
+  });
+
   return (
-    <div onWheel={onWheel} id="graph">
+    <div
+      onWheel={onWheel}
+      id="graph"
+      ref={graphRef}
+      data-panzoom-x={panzoom.pan.x}
+      data-panzoom-y={panzoom.pan.y}
+      data-panzoom-zoom={panzoom.zoom}
+    >
       <p className="Graph__zoom-indicator">
-        {zoom !== 1 && Math.floor(zoom * 100) + "% zoom"}
+        {panzoom.zoom !== 1 && Math.floor(panzoom.zoom * 100) + "% zoom"}
       </p>
       <div id="itemsContainer">
         <svg id="arrows">

--- a/src/scripts/App/Graph/Graph.tsx
+++ b/src/scripts/App/Graph/Graph.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { initGraph, updatePanzoom } from "@/graph";
+import { initGraph } from "@/graph";
 
 import "./Graph.css";
 import { snap } from "@/misc";
@@ -15,10 +15,9 @@ const Graph = (): JSX.Element => {
     setPanzoom((state) => ({ ...state, zoom: newZoom }));
   };
 
-  useEffect(updatePanzoom, [panzoom]);
-
   const graphRef = useRef<HTMLDivElement>(null);
 
+  // Update panzoom when the graph sends a graphmoved event
   useEffect(() => {
     if (!graphRef.current) return;
     const element = graphRef.current;
@@ -29,12 +28,15 @@ const Graph = (): JSX.Element => {
         pan: { x: number; y: number };
       }>;
       setPanzoom((state) => ({ ...state, pan }));
-
-      updatePanzoom();
     };
     element.addEventListener("graphmoved", handler);
     return () => element.removeEventListener("graphmoved", handler);
   });
+
+  const itemsContainerTransform = `
+    translate(${panzoom.pan.x}px, ${panzoom.pan.y}px)
+    scale(${panzoom.zoom})
+  `;
 
   return (
     <div
@@ -48,7 +50,7 @@ const Graph = (): JSX.Element => {
       <p className="Graph__zoom-indicator">
         {panzoom.zoom !== 1 && Math.floor(panzoom.zoom * 100) + "% zoom"}
       </p>
-      <div id="itemsContainer">
+      <div id="itemsContainer" style={{ transform: itemsContainerTransform }}>
         <svg id="arrows">
           <defs>
             <marker

--- a/src/scripts/App/Graph/Graph.tsx
+++ b/src/scripts/App/Graph/Graph.tsx
@@ -7,19 +7,19 @@ import { snap } from "@/misc";
 const Graph = (): JSX.Element => {
   useEffect(initGraph, []);
 
-  const [window, setWindow] = useState({ pan: { x: 0, y: 0 }, zoom: 1 });
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
 
   const onWheel: React.WheelEventHandler = (event) => {
     const factor = event.deltaY < 0 ? 1.1 : 0.9;
     const target = 1;
     const offset = 0.1;
-    const newZoom = snap(target)(offset)(window.zoom * factor);
-    setWindow((state) => ({ ...state, zoom: newZoom }));
+    setZoom(snap(target)(offset)(zoom * factor));
   };
 
   const graphRef = useRef<HTMLDivElement>(null);
 
-  // Update window when the graph sends a graphmoved event
+  // Update pan when the graph sends a graphmoved event
   useEffect(() => {
     if (!graphRef.current) return;
     const element = graphRef.current;
@@ -29,28 +29,25 @@ const Graph = (): JSX.Element => {
       } = event as CustomEvent<{
         pan: { x: number; y: number };
       }>;
-      setWindow((state) => ({ ...state, pan }));
+      setPan(pan);
     };
     element.addEventListener("graphmoved", handler);
     return () => element.removeEventListener("graphmoved", handler);
   });
 
-  const itemsContainerTransform = `
-    translate(${window.pan.x}px, ${window.pan.y}px)
-    scale(${window.zoom})
-  `;
+  const itemsContainerTransform = `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`;
 
   return (
     <div
       onWheel={onWheel}
       id="graph"
       ref={graphRef}
-      data-window-pan-x={window.pan.x}
-      data-window-pan-y={window.pan.y}
-      data-window-zoom={window.zoom}
+      data-pan-x={pan.x}
+      data-pan-y={pan.y}
+      data-zoom={zoom}
     >
       <p className="Graph__zoom-indicator">
-        {window.zoom !== 1 && Math.floor(window.zoom * 100) + "% zoom"}
+        {zoom !== 1 && Math.floor(zoom * 100) + "% zoom"}
       </p>
       <div id="itemsContainer" style={{ transform: itemsContainerTransform }}>
         <svg id="arrows">

--- a/src/scripts/graph.ts
+++ b/src/scripts/graph.ts
@@ -6,7 +6,7 @@ import {
   intersectLineBox,
   Point,
 } from "./geometry.js";
-import { getElementById, removeFromArray, snap } from "./misc.js";
+import { getElementById, removeFromArray } from "./misc.js";
 
 interface HTMLTaskElement extends HTMLElement {
   textContent: string;

--- a/src/scripts/graph.ts
+++ b/src/scripts/graph.ts
@@ -306,15 +306,11 @@ function updateZoomIndicator() {
     panzoom.zoom === 1 ? "" : Math.floor(panzoom.zoom * 100) + "% zoom";
 }
 
-function setupZoom() {
-  const graphContainer = getElementById("graph");
-  graphContainer.onwheel = (event) => {
-    const factor = event.deltaY < 0 ? 1.1 : 0.9;
-    panzoom.zoom = snap(1)(0.1)(panzoom.zoom * factor);
-    updatePanzoom();
-    updateZoomIndicator();
-  };
-}
+export const updateZoom = (factor: number): void => {
+  panzoom.zoom = snap(1)(0.1)(panzoom.zoom * factor);
+  updatePanzoom();
+  updateZoomIndicator();
+};
 
 function moveTask(task: HTMLTaskElement, pos: Point) {
   task.style.left = pos.x + "px";
@@ -323,7 +319,6 @@ function moveTask(task: HTMLTaskElement, pos: Point) {
 }
 
 export function initGraph(): void {
-  setupZoom();
   const graphContainer = getElementById("graph");
   graphContainer.onpointerdown = (event) => {
     event.preventDefault();

--- a/src/scripts/graph.ts
+++ b/src/scripts/graph.ts
@@ -73,10 +73,10 @@ function getViewCenter(): Point {
   const graphContainer = getElementById("graph");
   const box = getOffsetBox(graphContainer);
   const viewCenter = getBoxCenter(box);
-  const window = getWindow();
+  const { pan } = getPanZoom();
   return {
-    x: viewCenter.x - window.pan.x,
-    y: viewCenter.y - window.pan.y,
+    x: viewCenter.x - pan.x,
+    y: viewCenter.y - pan.y,
   };
 }
 
@@ -272,23 +272,19 @@ function updatePath(path: HTMLDependencyElement, dest?: Point) {
   }
 }
 
-const getWindow = () => {
+const getPanZoom = () => {
   const graph = getElementById("graph");
-  const { windowPanX, windowPanY, windowZoom } = graph.dataset;
+  const { panX, panY, zoom } = graph.dataset;
 
-  if (
-    windowPanX === undefined ||
-    windowPanY === undefined ||
-    windowZoom === undefined
-  )
-    throw new Error("window values missing");
+  if (panX === undefined || panY === undefined || zoom === undefined)
+    throw new Error("pan or zoom values missing");
 
   return {
     pan: {
-      x: parseFloat(windowPanX),
-      y: parseFloat(windowPanY),
+      x: parseFloat(panX),
+      y: parseFloat(panY),
     },
-    zoom: parseFloat(windowZoom),
+    zoom: parseFloat(zoom),
   };
 };
 
@@ -297,9 +293,9 @@ function onGraphDragStart(event: PointerEvent) {
   itemsContainer.setPointerCapture(event.pointerId);
   let previousPosition = { x: event.clientX, y: event.clientY };
   const onPointerMove = (event: PointerEvent) => {
-    const window = getWindow();
-    const x = window.pan.x + event.clientX - previousPosition.x;
-    const y = window.pan.y + event.clientY - previousPosition.y;
+    const { pan } = getPanZoom();
+    const x = pan.x + event.clientX - previousPosition.x;
+    const y = pan.y + event.clientY - previousPosition.y;
     previousPosition = { x: event.clientX, y: event.clientY };
 
     const graphContainer = getElementById("graph");

--- a/src/scripts/graph.ts
+++ b/src/scripts/graph.ts
@@ -274,21 +274,21 @@ function updatePath(path: HTMLDependencyElement, dest?: Point) {
 
 const getWindow = () => {
   const graph = getElementById("graph");
-  const windowX = graph.dataset.windowX;
-  const windowY = graph.dataset.windowY;
+  const windowPanX = graph.dataset.windowPanX;
+  const windowPanY = graph.dataset.windowPanY;
   const windowZoom = graph.dataset.windowZoom;
 
   if (
-    windowX === undefined ||
-    windowY === undefined ||
+    windowPanX === undefined ||
+    windowPanY === undefined ||
     windowZoom === undefined
   )
     throw new Error("window values missing");
 
   return {
     pan: {
-      x: parseFloat(windowX),
-      y: parseFloat(windowY),
+      x: parseFloat(windowPanX),
+      y: parseFloat(windowPanY),
     },
     zoom: parseFloat(windowZoom),
   };

--- a/src/scripts/graph.ts
+++ b/src/scripts/graph.ts
@@ -274,9 +274,7 @@ function updatePath(path: HTMLDependencyElement, dest?: Point) {
 
 const getWindow = () => {
   const graph = getElementById("graph");
-  const windowPanX = graph.dataset.windowPanX;
-  const windowPanY = graph.dataset.windowPanY;
-  const windowZoom = graph.dataset.windowZoom;
+  const { windowPanX, windowPanY, windowZoom } = graph.dataset;
 
   if (
     windowPanX === undefined ||

--- a/src/scripts/graph.ts
+++ b/src/scripts/graph.ts
@@ -73,10 +73,10 @@ function getViewCenter(): Point {
   const graphContainer = getElementById("graph");
   const box = getOffsetBox(graphContainer);
   const viewCenter = getBoxCenter(box);
-  const panzoom = getPanzoom();
+  const window = getWindow();
   return {
-    x: viewCenter.x - panzoom.pan.x,
-    y: viewCenter.y - panzoom.pan.y,
+    x: viewCenter.x - window.pan.x,
+    y: viewCenter.y - window.pan.y,
   };
 }
 
@@ -272,25 +272,25 @@ function updatePath(path: HTMLDependencyElement, dest?: Point) {
   }
 }
 
-const getPanzoom = () => {
+const getWindow = () => {
   const graph = getElementById("graph");
-  const panzoomX = graph.dataset.panzoomX;
-  const panzoomY = graph.dataset.panzoomY;
-  const panzoomZoom = graph.dataset.panzoomZoom;
+  const windowX = graph.dataset.windowX;
+  const windowY = graph.dataset.windowY;
+  const windowZoom = graph.dataset.windowZoom;
 
   if (
-    panzoomX === undefined ||
-    panzoomY === undefined ||
-    panzoomZoom === undefined
+    windowX === undefined ||
+    windowY === undefined ||
+    windowZoom === undefined
   )
-    throw new Error("panzoom values missing");
+    throw new Error("window values missing");
 
   return {
     pan: {
-      x: parseFloat(panzoomX),
-      y: parseFloat(panzoomY),
+      x: parseFloat(windowX),
+      y: parseFloat(windowY),
     },
-    zoom: parseFloat(panzoomZoom),
+    zoom: parseFloat(windowZoom),
   };
 };
 
@@ -299,9 +299,9 @@ function onGraphDragStart(event: PointerEvent) {
   itemsContainer.setPointerCapture(event.pointerId);
   let previousPosition = { x: event.clientX, y: event.clientY };
   const onPointerMove = (event: PointerEvent) => {
-    const panzoom = getPanzoom();
-    const x = panzoom.pan.x + event.clientX - previousPosition.x;
-    const y = panzoom.pan.y + event.clientY - previousPosition.y;
+    const window = getWindow();
+    const x = window.pan.x + event.clientX - previousPosition.x;
+    const y = window.pan.y + event.clientY - previousPosition.y;
     previousPosition = { x: event.clientX, y: event.clientY };
 
     const graphContainer = getElementById("graph");

--- a/src/scripts/graph.ts
+++ b/src/scripts/graph.ts
@@ -300,16 +300,10 @@ function onGraphDragStart(event: PointerEvent) {
   itemsContainer.addEventListener("pointerup", onPointerEnd);
 }
 
-function updateZoomIndicator() {
-  const zoomIndicator = getElementById("zoomIndicator");
-  zoomIndicator.textContent =
-    panzoom.zoom === 1 ? "" : Math.floor(panzoom.zoom * 100) + "% zoom";
-}
-
-export const updateZoom = (factor: number): void => {
+export const updateZoom = (factor: number): number => {
   panzoom.zoom = snap(1)(0.1)(panzoom.zoom * factor);
   updatePanzoom();
-  updateZoomIndicator();
+  return panzoom.zoom;
 };
 
 function moveTask(task: HTMLTaskElement, pos: Point) {
@@ -421,5 +415,4 @@ export function initGraph(): void {
     }
   };
   sendSelectionChanged([]);
-  updateZoomIndicator();
 }

--- a/src/scripts/graph.ts
+++ b/src/scripts/graph.ts
@@ -294,12 +294,6 @@ const getPanzoom = () => {
   };
 };
 
-export function updatePanzoom(): void {
-  const itemsContainer = getElementById("itemsContainer");
-  const panzoom = getPanzoom();
-  itemsContainer.style.transform = `translate(${panzoom.pan.x}px, ${panzoom.pan.y}px) scale(${panzoom.zoom})`;
-}
-
 function onGraphDragStart(event: PointerEvent) {
   const itemsContainer = getElementById("itemsContainer");
   itemsContainer.setPointerCapture(event.pointerId);


### PR DESCRIPTION
Move as much of the panzoom logic as possible to React.

Because I could not get everything out the two need a way to communicate.

For this purpose, I pass down custom attributes from React to vanilla JS (`data-panzoom-x`, `data-panzoom-y`, `data-panzoom-zoom`)

And when `graph.js` wants to propagate a pan value change it sends a `graphmoved` custom event with the `pan` as `detail`, later handled by React.