### PR TITLE
Simplify code

### DIFF
--- a/src/scripts/App/App.tsx
+++ b/src/scripts/App/App.tsx
@@ -30,41 +30,6 @@ const App = (): JSX.Element => {
 
   const tasksSelected = useTasksSelected();
 
-  const renderToolbar = () => {
-    const onCreateTask = () => {
-      const newTask = getElementById("newTask");
-      newTask.style.display = "block";
-      newTask.focus();
-    };
-
-    const onChangeLinkMode = () => setLinkMode((state) => !state);
-
-    const onComplete = () => {
-      completeSelected();
-      saveToLocalStorage();
-    };
-
-    const onDelete = () => {
-      deleteSelected();
-      saveToLocalStorage();
-    };
-
-    return tasksSelected ? (
-      <Toolbar
-        tasksSelected={true}
-        onComplete={onComplete}
-        onDelete={onDelete}
-      />
-    ) : (
-      <Toolbar
-        tasksSelected={false}
-        linkMode={linkMode}
-        onCreateTask={onCreateTask}
-        onChangeLinkMode={onChangeLinkMode}
-      />
-    );
-  };
-
   useAppShortcuts(loadFromFile);
 
   return (
@@ -90,7 +55,26 @@ const App = (): JSX.Element => {
           closeMenubar();
         }}
       />
-      {renderToolbar()}
+
+      <Toolbar
+        tasksSelected={tasksSelected}
+        linkMode={linkMode}
+        onChangeLinkMode={() => setLinkMode((mode) => !mode)}
+        onCreateTask={() => {
+          const newTask = getElementById("newTask");
+          newTask.style.display = "block";
+          newTask.focus();
+        }}
+        onComplete={() => {
+          completeSelected();
+          saveToLocalStorage();
+        }}
+        onDelete={() => {
+          deleteSelected();
+          saveToLocalStorage();
+        }}
+      />
+
       <GraphComponent />
     </>
   );

--- a/src/scripts/App/App.tsx
+++ b/src/scripts/App/App.tsx
@@ -24,38 +24,7 @@ export const closeMenubar = (): void => {
 const App = (): JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const renderGraphInput = () => {
-    const onLoad = (graph: Graph) => {
-      loadGraph(graph);
-      saveToLocalStorage();
-      closeMenubar();
-    };
-
-    return <GraphInput onLoad={onLoad} ref={fileInputRef} />;
-  };
-
   const loadFromFile = () => fileInputRef.current?.click();
-
-  const renderMenuBar = () => {
-    const onSave = () => {
-      saveToFile();
-      closeMenubar();
-    };
-
-    const onNewGraph = () => {
-      clearGraph();
-      closeMenubar();
-    };
-
-    return (
-      <MenuBar
-        onClose={closeMenubar}
-        onLoad={loadFromFile}
-        onNewGraph={onNewGraph}
-        onSave={onSave}
-      />
-    );
-  };
 
   const [linkMode, setLinkMode] = useState(false);
 
@@ -100,8 +69,27 @@ const App = (): JSX.Element => {
 
   return (
     <>
-      {renderGraphInput()}
-      {renderMenuBar()}
+      <GraphInput
+        onLoad={(graph) => {
+          loadGraph(graph);
+          saveToLocalStorage();
+          closeMenubar();
+        }}
+        ref={fileInputRef}
+      />
+
+      <MenuBar
+        onClose={closeMenubar}
+        onLoad={loadFromFile}
+        onNewGraph={() => {
+          clearGraph();
+          closeMenubar();
+        }}
+        onSave={() => {
+          saveToFile();
+          closeMenubar();
+        }}
+      />
       {renderToolbar()}
       <GraphComponent />
     </>

--- a/src/scripts/App/Toolbar/NoneSelectedButtons.tsx
+++ b/src/scripts/App/Toolbar/NoneSelectedButtons.tsx
@@ -16,11 +16,11 @@ const NotSelectedButtons = ({
       aria-label="Change Link Mode"
       onClick={onChangeLinkMode}
       className={`
-              Toolbar__button
-              Toolbar__button-change-link-mode
-              ${linkMode ? "Toolbar__button-change-link-mode--active" : ""}
-              iconButton
-            `}
+        Toolbar__button
+        Toolbar__button-change-link-mode
+        ${linkMode ? "Toolbar__button-change-link-mode--active" : ""}
+        iconButton
+      `}
     />
     <button
       aria-label="Create Task"

--- a/src/scripts/App/Toolbar/NoneSelectedButtons.tsx
+++ b/src/scripts/App/Toolbar/NoneSelectedButtons.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+type Props = {
+  linkMode: boolean;
+  onChangeLinkMode: () => void;
+  onCreateTask: () => void;
+};
+
+const NotSelectedButtons = ({
+  linkMode,
+  onChangeLinkMode,
+  onCreateTask,
+}: Props): JSX.Element => (
+  <>
+    <button
+      aria-label="Change Link Mode"
+      onClick={onChangeLinkMode}
+      className={`
+              Toolbar__button
+              Toolbar__button-change-link-mode
+              ${linkMode ? "Toolbar__button-change-link-mode--active" : ""}
+              iconButton
+            `}
+    />
+    <button
+      aria-label="Create Task"
+      onClick={onCreateTask}
+      className="Toolbar__button Toolbar__button-create-task iconButton"
+    />
+  </>
+);
+
+export default NotSelectedButtons;

--- a/src/scripts/App/Toolbar/SomeSelectedButtons.tsx
+++ b/src/scripts/App/Toolbar/SomeSelectedButtons.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+type Props = {
+  onComplete: () => void;
+  onDelete: () => void;
+};
+
+const SomeSelectedButtons = ({ onComplete, onDelete }: Props): JSX.Element => (
+  <>
+    <button
+      aria-label="Delete Selected"
+      onClick={onDelete}
+      className="Toolbar__button Toolbar__button-delete-selected iconButton"
+    />
+    <button
+      aria-label="Complete Selected"
+      onClick={onComplete}
+      className="Toolbar__button Toolbar__button-complete-selected iconButton"
+    />
+  </>
+);
+
+export default SomeSelectedButtons;

--- a/src/scripts/App/Toolbar/Toolbar.tsx
+++ b/src/scripts/App/Toolbar/Toolbar.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import NoneSelectedButtons from "./NoneSelectedButtons";
+import SomeSelectedButtons from "./SomeSelectedButtons";
 
 import "./Toolbar.css";
 
@@ -11,56 +13,6 @@ type Props = {
   onDelete: () => void;
 };
 
-type NotSelectedButtonsProps = {
-  linkMode: boolean;
-  onChangeLinkMode: () => void;
-  onCreateTask: () => void;
-};
-
-const NotSelectedButtons = ({
-  linkMode,
-  onChangeLinkMode,
-  onCreateTask,
-}: NotSelectedButtonsProps) => (
-  <>
-    <button
-      aria-label="Change Link Mode"
-      onClick={onChangeLinkMode}
-      className={`
-              Toolbar__button
-              Toolbar__button-change-link-mode
-              ${linkMode ? "Toolbar__button-change-link-mode--active" : ""}
-              iconButton
-            `}
-    />
-    <button
-      aria-label="Create Task"
-      onClick={onCreateTask}
-      className="Toolbar__button Toolbar__button-create-task iconButton"
-    />
-  </>
-);
-
-type SelectedButtonsProps = {
-  onComplete: () => void;
-  onDelete: () => void;
-};
-
-const SelectedButtons = ({ onComplete, onDelete }: SelectedButtonsProps) => (
-  <>
-    <button
-      aria-label="Delete Selected"
-      onClick={onDelete}
-      className="Toolbar__button Toolbar__button-delete-selected iconButton"
-    />
-    <button
-      aria-label="Complete Selected"
-      onClick={onComplete}
-      className="Toolbar__button Toolbar__button-complete-selected iconButton"
-    />
-  </>
-);
-
 const Toolbar = ({
   tasksSelected,
   linkMode,
@@ -71,9 +23,9 @@ const Toolbar = ({
 }: Props): JSX.Element => (
   <div className="Toolbar">
     {tasksSelected ? (
-      <SelectedButtons onComplete={onComplete} onDelete={onDelete} />
+      <SomeSelectedButtons onComplete={onComplete} onDelete={onDelete} />
     ) : (
-      <NotSelectedButtons
+      <NoneSelectedButtons
         linkMode={linkMode}
         onChangeLinkMode={onChangeLinkMode}
         onCreateTask={onCreateTask}

--- a/src/scripts/App/Toolbar/Toolbar.tsx
+++ b/src/scripts/App/Toolbar/Toolbar.tsx
@@ -2,75 +2,93 @@ import React from "react";
 
 import "./Toolbar.css";
 
-type Props =
-  | {
-      tasksSelected: false;
-      linkMode: boolean;
-      onChangeLinkMode: () => void;
-      onCreateTask: () => void;
-    }
-  | {
-      tasksSelected: true;
-      onComplete: () => void;
-      onDelete: () => void;
-    };
+type Props = {
+  tasksSelected: boolean;
+  linkMode: boolean;
+  onChangeLinkMode: () => void;
+  onCreateTask: () => void;
+  onComplete: () => void;
+  onDelete: () => void;
+};
 
-const Toolbar = (props: Props): JSX.Element => {
-  const renderButtons = () => {
-    if (!props.tasksSelected) {
-      const { linkMode, onChangeLinkMode, onCreateTask } = props;
-      return (
-        <>
-          <button
-            aria-label="Change Link Mode"
-            onClick={onChangeLinkMode}
-            className={`
+type NotSelectedButtonsProps = {
+  linkMode: boolean;
+  onChangeLinkMode: () => void;
+  onCreateTask: () => void;
+};
+
+const NotSelectedButtons = ({
+  linkMode,
+  onChangeLinkMode,
+  onCreateTask,
+}: NotSelectedButtonsProps) => (
+  <>
+    <button
+      aria-label="Change Link Mode"
+      onClick={onChangeLinkMode}
+      className={`
               Toolbar__button
               Toolbar__button-change-link-mode
               ${linkMode ? "Toolbar__button-change-link-mode--active" : ""}
               iconButton
             `}
-          />
-          <button
-            aria-label="Create Task"
-            onClick={onCreateTask}
-            className="Toolbar__button Toolbar__button-create-task iconButton"
-          />
-        </>
-      );
-    }
-    // props.tasksSelected === true
-    const { onComplete, onDelete } = props;
-    return (
-      <>
-        <button
-          aria-label="Delete Selected"
-          onClick={onDelete}
-          className="Toolbar__button Toolbar__button-delete-selected iconButton"
-        />
-        <button
-          aria-label="Complete Selected"
-          onClick={onComplete}
-          className="Toolbar__button Toolbar__button-complete-selected iconButton"
-        />
-      </>
-    );
-  };
+    />
+    <button
+      aria-label="Create Task"
+      onClick={onCreateTask}
+      className="Toolbar__button Toolbar__button-create-task iconButton"
+    />
+  </>
+);
 
-  return (
-    <div className="Toolbar">
-      {renderButtons()}
-
-      {/* TODO Remove: Temporary element used to communicate with graph */}
-      <input
-        style={{ display: "none" }}
-        type="checkbox"
-        checked={!props.tasksSelected && props.linkMode}
-        id="linkModeCheckbox"
-        readOnly
-      />
-    </div>
-  );
+type SelectedButtonsProps = {
+  onComplete: () => void;
+  onDelete: () => void;
 };
+
+const SelectedButtons = ({ onComplete, onDelete }: SelectedButtonsProps) => (
+  <>
+    <button
+      aria-label="Delete Selected"
+      onClick={onDelete}
+      className="Toolbar__button Toolbar__button-delete-selected iconButton"
+    />
+    <button
+      aria-label="Complete Selected"
+      onClick={onComplete}
+      className="Toolbar__button Toolbar__button-complete-selected iconButton"
+    />
+  </>
+);
+
+const Toolbar = ({
+  tasksSelected,
+  linkMode,
+  onChangeLinkMode,
+  onCreateTask,
+  onComplete,
+  onDelete,
+}: Props): JSX.Element => (
+  <div className="Toolbar">
+    {tasksSelected ? (
+      <SelectedButtons onComplete={onComplete} onDelete={onDelete} />
+    ) : (
+      <NotSelectedButtons
+        linkMode={linkMode}
+        onChangeLinkMode={onChangeLinkMode}
+        onCreateTask={onCreateTask}
+      />
+    )}
+
+    {/* TODO Remove: Temporary element used to communicate with graph */}
+    <input
+      style={{ display: "none" }}
+      type="checkbox"
+      checked={!tasksSelected && linkMode}
+      id="linkModeCheckbox"
+      readOnly
+    />
+  </div>
+);
 
 export default Toolbar;


### PR DESCRIPTION
- Simplified code by removing the `renderXXX` pattern

- Simplify Toolbar creation by passing down all necessary props to the Toolbar object

- Simplify Toolbar code with two sub components