### PR TITLE
Move the Menu Bar open button to React

### DIFF
--- a/src/scripts/App/App.css
+++ b/src/scripts/App/App.css
@@ -1,4 +1,4 @@
-#menubarOpenButton {
+.App__menu-bar-open-button {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/scripts/App/App.css
+++ b/src/scripts/App/App.css
@@ -1,0 +1,11 @@
+#menubarOpenButton {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2.1rem;
+  height: 2.1rem;
+  margin-left: 1rem;
+  margin-top: 0.8rem;
+  z-index: 1;
+  background-image: url("resources/feather/menu.svg");
+}

--- a/src/scripts/App/App.tsx
+++ b/src/scripts/App/App.tsx
@@ -46,7 +46,7 @@ const App = (): JSX.Element => {
       <button
         className="App__menu-bar-open-button iconButton"
         onClick={() => setMenuBarOpen(true)}
-      ></button>
+      />
       <MenuBar
         open={menuBarOpen}
         onClose={closeMenuBar}

--- a/src/scripts/App/App.tsx
+++ b/src/scripts/App/App.tsx
@@ -18,16 +18,13 @@ import GraphComponent from "./Graph/Graph";
 
 import "./App.css";
 
-export const closeMenubar = (): void => {
-  const menubar = getElementById("menubar");
-
-  menubar.classList.remove("active");
-};
-
 const App = (): JSX.Element => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const loadFromFile = () => fileInputRef.current?.click();
+
+  const [menuBarOpen, setMenuBarOpen] = useState(false);
+  const closeMenuBar = () => setMenuBarOpen(false);
 
   const [linkMode, setLinkMode] = useState(false);
 
@@ -41,22 +38,26 @@ const App = (): JSX.Element => {
         onLoad={(graph) => {
           loadGraph(graph);
           saveToLocalStorage();
-          closeMenubar();
+          closeMenuBar();
         }}
         ref={fileInputRef}
       />
 
-      <button id="menubarOpenButton" className="iconButton"></button>
+      <button
+        className="App__menu-bar-open-button iconButton"
+        onClick={() => setMenuBarOpen(true)}
+      ></button>
       <MenuBar
-        onClose={closeMenubar}
+        open={menuBarOpen}
+        onClose={closeMenuBar}
         onLoad={loadFromFile}
         onNewGraph={() => {
           clearGraph();
-          closeMenubar();
+          closeMenuBar();
         }}
         onSave={() => {
           saveToFile();
-          closeMenubar();
+          closeMenuBar();
         }}
       />
 

--- a/src/scripts/App/App.tsx
+++ b/src/scripts/App/App.tsx
@@ -16,6 +16,8 @@ import GraphInput from "./GraphInput";
 import useTasksSelected from "./useTasksSelected";
 import GraphComponent from "./Graph/Graph";
 
+import "./App.css";
+
 export const closeMenubar = (): void => {
   const menubar = getElementById("menubar");
 
@@ -44,6 +46,7 @@ const App = (): JSX.Element => {
         ref={fileInputRef}
       />
 
+      <button id="menubarOpenButton" className="iconButton"></button>
       <MenuBar
         onClose={closeMenubar}
         onLoad={loadFromFile}
@@ -75,7 +78,6 @@ const App = (): JSX.Element => {
           saveToLocalStorage();
         }}
       />
-
       <GraphComponent />
     </>
   );

--- a/src/scripts/App/App.tsx
+++ b/src/scripts/App/App.tsx
@@ -79,6 +79,7 @@ const App = (): JSX.Element => {
           saveToLocalStorage();
         }}
       />
+
       <GraphComponent />
     </>
   );

--- a/src/scripts/App/MenuBar/MenuBar.css
+++ b/src/scripts/App/MenuBar/MenuBar.css
@@ -16,6 +16,11 @@
   transform: translateX(-100%);
 }
 
+.MenuBar--open {
+  transform: translate(0);
+  box-shadow: 0.2rem 0 1rem rgba(0, 0, 0, 0.5);
+}
+
 .MenuBar__close-button {
   position: absolute;
   top: 0;
@@ -33,11 +38,6 @@
 .MenuBar__title {
   font-family: "PermanentMarker";
   font-size: 3rem;
-}
-
-.MenuBar.active {
-  transform: translate(0);
-  box-shadow: 0.2rem 0 1rem rgba(0, 0, 0, 0.5);
 }
 
 .MenuBar button {

--- a/src/scripts/App/MenuBar/MenuBar.test.tsx
+++ b/src/scripts/App/MenuBar/MenuBar.test.tsx
@@ -15,28 +15,28 @@ const noopProps = {
 describe("MenuBar", () => {
   test("calls onLoad", () => {
     const onLoad = jest.fn();
-    render(<MenuBar {...noopProps} onLoad={onLoad} />);
+    render(<MenuBar open {...noopProps} onLoad={onLoad} />);
     userEvent.click(screen.getByText("Load"));
     expect(onLoad).toHaveBeenCalled();
   });
 
   test("calls onSave", () => {
     const onSave = jest.fn();
-    render(<MenuBar {...noopProps} onSave={onSave} />);
+    render(<MenuBar open {...noopProps} onSave={onSave} />);
     userEvent.click(screen.getByText("Save"));
     expect(onSave).toHaveBeenCalled();
   });
 
   test("calls onNewGraph", () => {
     const onNewGraph = jest.fn();
-    render(<MenuBar {...noopProps} onNewGraph={onNewGraph} />);
+    render(<MenuBar open {...noopProps} onNewGraph={onNewGraph} />);
     userEvent.click(screen.getByText("New Graph"));
     expect(onNewGraph).toHaveBeenCalled();
   });
 
   test("calls onClose", () => {
     const onClose = jest.fn();
-    render(<MenuBar {...noopProps} onClose={onClose} />);
+    render(<MenuBar open {...noopProps} onClose={onClose} />);
     userEvent.click(screen.getByLabelText("Close Menu"));
     expect(onClose).toHaveBeenCalled();
   });

--- a/src/scripts/App/MenuBar/MenuBar.tsx
+++ b/src/scripts/App/MenuBar/MenuBar.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import "./MenuBar.css";
 
 type Props = {
+  open: boolean;
   onClose: () => void;
   onSave: () => void;
   onLoad: () => void;
@@ -10,13 +11,14 @@ type Props = {
 };
 
 const MenuBar = ({
+  open,
   onClose,
   onLoad,
   onSave,
   onNewGraph,
 }: Props): JSX.Element => {
   return (
-    <div id="menubar" className="MenuBar">
+    <div className={`MenuBar ${open ? "MenuBar--open" : ""}`}>
       <h1 className="MenuBar__title">TaskGraph</h1>
       <button
         aria-label="Close Menu"

--- a/src/scripts/index.tsx
+++ b/src/scripts/index.tsx
@@ -8,13 +8,6 @@ import { loadFromLocalStorage, saveToLocalStorage } from "./storage.js";
 
 const setupApp = () => {
   ReactDOM.render(<App />, document.getElementById("root"));
-
-  const menubarButton = getElementById("menubarOpenButton");
-  menubarButton.addEventListener("click", () => {
-    const menubar = getElementById("menubar");
-
-    menubar.classList.add("active");
-  });
 };
 
 function setupNewTask() {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -9,8 +9,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <button id="menubarOpenButton" class="iconButton"></button>
-
     <input id="newTask" type="text" />
   </body>
 </html>

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -50,15 +50,3 @@ body {
 button {
   cursor: pointer;
 }
-
-#menubarOpenButton {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 2.1rem;
-  height: 2.1rem;
-  margin-left: 1rem;
-  margin-top: 0.8rem;
-  z-index: 1;
-  background-image: url("resources/feather/menu.svg");
-}


### PR DESCRIPTION
- Naming is now clear Menu Bar is two words
- Naming of the state is now clear: `open` rather than mix of `open` and `active`