### PR TITLE
Add Google Analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,11 +24,19 @@
         analytics_storage: "denied",
       });
 
+      const dev = "%MODE%" === "development";
+
+      // Cookies are necessary for Google Analytics Debug Mode
+      if (dev)
+        gtag("consent", "update", {
+          ad_storage: "granted",
+          analytics_storage: "granted",
+        });
+
       gtag("js", new Date());
 
-      gtag("config", "G-1WBNT9GR3R", {
-        debug_mode: "%MODE%" === "development",
-      });
+      const options = dev ? { debug_mode: true } : undefined;
+      gtag("config", "G-1WBNT9GR3R", options);
     </script>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,9 @@
 
       gtag("js", new Date());
 
-      gtag("config", "G-1WBNT9GR3R");
+      gtag("config", "G-1WBNT9GR3R", {
+        debug_mode: "%MODE%" === "development",
+      });
     </script>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,28 @@
     <title>TaskGraph</title>
     <script src="dist/index.js" type="module"></script>
     <link rel="stylesheet" type="text/css" href="style.css" />
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-1WBNT9GR3R"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+
+      // Disable cookies by default
+      gtag("consent", "default", {
+        ad_storage: "denied",
+        analytics_storage: "denied",
+      });
+
+      gtag("js", new Date());
+
+      gtag("config", "G-1WBNT9GR3R");
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
I really wanted to not use Google Analytics for that, Matomo seemed great, but you have to either host it yourself, and I can't invest that time for that now, or pay a premium of 30e/month.

Disabled cookies to stay GDPR compliant without a prompt

I tried running it locally but did not yet get an update about it, probably because it takes time to update.