### PR TITLE
Mirror the state of the graph in react

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -42,7 +42,12 @@ const App = (): JSX.Element => {
   // Update localstorage when graph is updated
   useEffect(() => graph && saveToLocalStorage(graph), [graph]);
 
-  useAppShortcuts({ loadFromFile, insertMode, updateGraph, onCreateTask });
+  const onDelete = () => {
+    deleteSelected();
+    updateGraph();
+  };
+
+  useAppShortcuts({ loadFromFile, insertMode, onDelete, onCreateTask });
 
   return (
     <>
@@ -83,10 +88,7 @@ const App = (): JSX.Element => {
           completeSelected();
           updateGraph();
         }}
-        onDelete={() => {
-          deleteSelected();
-          updateGraph();
-        }}
+        onDelete={onDelete}
       />
 
       <GraphComponent updateGraph={updateGraph} />

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   addTask,
@@ -6,6 +6,8 @@ import {
   completeSelected,
   deleteSelected,
   loadGraph,
+  getGraph,
+  Graph as GraphData,
 } from "@/graph";
 import { saveToFile, saveToLocalStorage } from "@/storage";
 
@@ -34,14 +36,20 @@ const App = (): JSX.Element => {
 
   const tasksSelected = useTasksSelected();
 
-  useAppShortcuts({ loadFromFile, insertMode, onCreateTask });
+  const [graph, setGraph] = useState<GraphData>();
+  const updateGraph = useCallback(() => setGraph(getGraph()), []);
+
+  // Update localstorage when graph is updated
+  useEffect(() => graph && saveToLocalStorage(graph), [graph]);
+
+  useAppShortcuts({ loadFromFile, insertMode, updateGraph, onCreateTask });
 
   return (
     <>
       <GraphInput
         onLoad={(graph) => {
           loadGraph(graph);
-          saveToLocalStorage();
+          updateGraph();
           closeMenuBar();
         }}
         ref={fileInputRef}
@@ -57,6 +65,7 @@ const App = (): JSX.Element => {
         onLoad={loadFromFile}
         onNewGraph={() => {
           clearGraph();
+          updateGraph();
           closeMenuBar();
         }}
         onSave={() => {
@@ -72,21 +81,21 @@ const App = (): JSX.Element => {
         onCreateTask={onCreateTask}
         onComplete={() => {
           completeSelected();
-          saveToLocalStorage();
+          updateGraph();
         }}
         onDelete={() => {
           deleteSelected();
-          saveToLocalStorage();
+          updateGraph();
         }}
       />
 
-      <GraphComponent />
+      <GraphComponent updateGraph={updateGraph} />
 
       {insertMode && (
         <NewTaskInput
           onNewTask={(task) => {
             addTask(task);
-            saveToLocalStorage();
+            updateGraph();
             setInsertMode(false);
           }}
           onCancel={() => setInsertMode(false)}

--- a/src/App/useAppShortcuts.ts
+++ b/src/App/useAppShortcuts.ts
@@ -1,4 +1,4 @@
-import { deleteSelected, selectAll } from "@/graph";
+import { selectAll } from "@/graph";
 import { saveToFile } from "@/storage";
 import useKeyboardShortcuts, { Shortcut } from "@/useKeyboardShortcuts";
 
@@ -6,14 +6,10 @@ type Props = {
   loadFromFile: () => void;
   insertMode: boolean;
   onCreateTask: () => void;
-  updateGraph: () => void;
+  onDelete: () => void;
 };
 
-const getAppShortcuts = ({
-  loadFromFile,
-  onCreateTask,
-  updateGraph,
-}: Props) => {
+const getAppShortcuts = ({ loadFromFile, onCreateTask, onDelete }: Props) => {
   const selectAllShortcut: Shortcut = {
     keys: ["a"],
     callback: (event) => {
@@ -28,10 +24,7 @@ const getAppShortcuts = ({
 
   const deleteSelectedShortcut = {
     keys: ["d", "Delete"],
-    callback: () => {
-      deleteSelected();
-      updateGraph();
-    },
+    callback: onDelete,
   };
 
   const openFile: Shortcut = {

--- a/src/App/useAppShortcuts.ts
+++ b/src/App/useAppShortcuts.ts
@@ -1,14 +1,19 @@
 import { deleteSelected, selectAll } from "@/graph";
-import { saveToFile, saveToLocalStorage } from "@/storage";
+import { saveToFile } from "@/storage";
 import useKeyboardShortcuts, { Shortcut } from "@/useKeyboardShortcuts";
 
 type Props = {
   loadFromFile: () => void;
   insertMode: boolean;
   onCreateTask: () => void;
+  updateGraph: () => void;
 };
 
-const getAppShortcuts = ({ loadFromFile, onCreateTask }: Props) => {
+const getAppShortcuts = ({
+  loadFromFile,
+  onCreateTask,
+  updateGraph,
+}: Props) => {
   const selectAllShortcut: Shortcut = {
     keys: ["a"],
     callback: (event) => {
@@ -25,7 +30,7 @@ const getAppShortcuts = ({ loadFromFile, onCreateTask }: Props) => {
     keys: ["d", "Delete"],
     callback: () => {
       deleteSelected();
-      saveToLocalStorage();
+      updateGraph();
     },
   };
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,4 +1,4 @@
-import { getGraph, loadGraph } from "./graph";
+import { getGraph, Graph } from "./graph";
 
 function downloadFile(
   filename: string,
@@ -26,16 +26,15 @@ function saveToFile(): void {
   );
 }
 
-function saveToLocalStorage(): void {
-  const graph = getGraph();
+function saveToLocalStorage(graph: Graph): void {
   window.localStorage.setItem("graph", JSON.stringify(graph));
 }
 
-function loadFromLocalStorage(): void {
+function loadFromLocalStorage(): Graph | null {
   const graphItem = window.localStorage.getItem("graph");
-  if (!graphItem) return;
+  if (!graphItem) return null;
   const graph = JSON.parse(graphItem);
-  loadGraph(graph);
+  return graph as Graph;
 }
 
 export { saveToFile, saveToLocalStorage, loadFromLocalStorage };


### PR DESCRIPTION
- Transformed `saveToLocalStorage` and `loadFromLocalStorage` to take parameter/return value rather than directly interacting with the graph
- When there is a graph update we call `updateGraph` that mirrors the state of the DOM (old way of storing the state) in a React state
- Whenever the react state is updated, we update the `localStorage` using this value

Having the graph state in React will enable us to migrate small parts of the graph